### PR TITLE
Bump up timeout for lambda functions to 10 seconds for local invokes

### DIFF
--- a/lib/cdk-day-stack.ts
+++ b/lib/cdk-day-stack.ts
@@ -35,6 +35,7 @@ export class CdkDayStack extends cdk.Stack {
       handler: 'app.handler',
       code: Code.fromAsset('src/put-translation'),
       tracing: Tracing.ACTIVE,
+      timeout: cdk.Duration.seconds(10),
       environment: {
         'TRANSLATE_BUS': translateBus.eventBusName
       }
@@ -61,6 +62,7 @@ export class CdkDayStack extends cdk.Stack {
       handler: 'app.handler',
       code: Code.fromAsset('src/get-translation'),
       tracing: Tracing.ACTIVE,
+      timeout: cdk.Duration.seconds(10),
       environment: {
         'TRANSLATE_TABLE': translateTable.tableName
       }
@@ -76,6 +78,7 @@ export class CdkDayStack extends cdk.Stack {
       handler: 'app.handler',
       code: Code.fromAsset('src/save-translation'),
       tracing: Tracing.ACTIVE,
+      timeout: cdk.Duration.seconds(10),
       environment:{
         'TRANSLATE_TABLE': translateTable.tableName
       }


### PR DESCRIPTION
*Issue # sam-beta-cdk local invoke times out with default 3 seconds when called from outside AWS envs.

*Description of changes:* Specify the Lambda function timeout to be 10 seconds to avoid this timeout when running remotely.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
